### PR TITLE
Add build job in check CI workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# Allow one concurrent deployment
+concurrency:
+  group: ${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Check job
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,11 +17,7 @@ jobs:
   # Check job
   check:
     name: Check Astro site
-
-    # Runs on Ubuntu
     runs-on: ubuntu-latest
-
-    # Maximum run time in minutes before the job is canceled
     timeout-minutes: 10
 
     steps:
@@ -38,3 +34,24 @@ jobs:
 
     - name: Check
       run: npm run check
+
+  # Build job
+  build:
+    name: Build Astro site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install Node 18
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+
+    - name: Clean install
+      run: npm clean-install
+
+    - name: Build
+      run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    name: Build Astro site
+    name: Build Astro site artifact
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
- Add build job in check CI to prevent build error on deploy.
- Add concurrency setting to cancel a workflow on an outdated commit.